### PR TITLE
[SDK] пример переопределения аудиодрайвера

### DIFF
--- a/app/src/main/java/ru/dgis/sdk/demo/Initialization.kt
+++ b/app/src/main/java/ru/dgis/sdk/demo/Initialization.kt
@@ -4,6 +4,7 @@ import ru.dgis.sdk.Context
 import ru.dgis.sdk.DGis
 import ru.dgis.sdk.LogLevel
 import ru.dgis.sdk.LogOptions
+import ru.dgis.sdk.demo.sound.SamplePlatformAudioDriver
 
 fun initializeDGis(appContext: android.content.Context): Context {
     return DGis.initialize(
@@ -11,6 +12,7 @@ fun initializeDGis(appContext: android.content.Context): Context {
         logOptions = LogOptions(
             customLevel = LogLevel.WARNING,
             customSink = createLogSink()
-        )
+        ),
+        platformAudioDriver = SamplePlatformAudioDriver()
     )
 }

--- a/app/src/main/java/ru/dgis/sdk/demo/sound/SamplePlatformAudioDriver.kt
+++ b/app/src/main/java/ru/dgis/sdk/demo/sound/SamplePlatformAudioDriver.kt
@@ -1,0 +1,67 @@
+package ru.dgis.sdk.demo.sound
+
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioManager
+import android.media.AudioTrack
+import android.util.Log
+import ru.dgis.sdk.platform.AudioDriver
+import ru.dgis.sdk.platform.AudioStreamReader
+import ru.dgis.sdk.platform.AvailableCallback
+
+class SamplePlatformAudioDriver : AudioDriver {
+    private companion object {
+        const val TAG = "PlatformAudioDriver"
+        const val SAMPLE_RATE = 22050
+    }
+
+    private var reader: AudioStreamReader? = null
+    private var callback: AvailableCallback? = null
+    private val player = createPlayer()
+    override fun setReader(reader: AudioStreamReader) {
+        Log.i(TAG, "setReader")
+        this.reader = reader
+    }
+
+    override fun setAvailableCallback(callback: AvailableCallback) {
+        Log.i(TAG, "setAvailableCallback")
+        this.callback = callback
+    }
+
+    override fun available(): Boolean {
+        Log.i(TAG, "available")
+        return true
+    }
+
+    override fun play() {
+        Log.i(TAG, "play")
+        val reader = this.reader ?: return
+        player.play()
+        do {
+            val buffer = reader.read().toShortArray()
+            player.write(buffer, 0, buffer.size)
+        } while (buffer.isNotEmpty())
+        player.stop()
+    }
+
+    private fun createPlayer(): AudioTrack {
+        val systemBufferSize = AudioTrack.getMinBufferSize(
+            SAMPLE_RATE,
+            AudioFormat.CHANNEL_OUT_MONO,
+            AudioFormat.ENCODING_PCM_16BIT
+        )
+        return AudioTrack(
+            AudioAttributes.Builder()
+                .setLegacyStreamType(AudioManager.STREAM_MUSIC)
+                .build(),
+            AudioFormat.Builder()
+                .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+                .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                .setSampleRate(SAMPLE_RATE)
+                .build(),
+            systemBufferSize,
+            AudioTrack.MODE_STREAM,
+            AudioManager.AUDIO_SESSION_ID_GENERATE
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ taskTree = "2.1.1"
 undercouch-download = "5.4.0"
 ktlint = "11.5.0"
 
-dgis-sdk = "10.2.0"
+dgis-sdk = "10.4.0"
 
 appcompat = "1.6.1"
 constraintlayout = "2.1.4"


### PR DESCRIPTION
В примере поднята версия MobileSDK до 10.4.0, в этой версии появилась возможность установки платоформенного аудиодрайвера.

Добавлен пример реализации интерфейса аудиодрайвера на платформе.
Реализованный пример используется при инициализации MobileSDK и используется навигатором для воспроизведения голосовых инструкций.